### PR TITLE
fix(docker): pin frontend build to amd64 to avoid QEMU timeout in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # --- STAGE 1: Frontend Build ---
-# Builds the SvelteKit SPA into static files
-FROM node:20-alpine AS frontend-builder
+# Builds the SvelteKit SPA into static files.
+# The output is pure HTML/CSS/JS — architecture-independent.
+# We pin to linux/amd64 so that multi-platform builds never run this
+# stage under slow QEMU emulation.
+FROM --platform=linux/amd64 node:20-alpine AS frontend-builder
 
 WORKDIR /frontend
 


### PR DESCRIPTION
The multi-platform Docker build (amd64+arm64) was running npm ci and npm run build under QEMU arm64 emulation, causing the CI job to exceed the 6-hour GitHub Actions timeout.

Since the SvelteKit SPA output is pure static HTML/CSS/JS (architecture- independent), we pin the frontend-builder stage to linux/amd64. This runs the Node.js build natively on the CI runner while still producing correct output for both platform targets.